### PR TITLE
chrome桌面请求模式下的ipad

### DIFF
--- a/src/shared/system-info.ts
+++ b/src/shared/system-info.ts
@@ -1,9 +1,9 @@
 import { userAgent } from "./browser-context";
 
 
-export const isIpad = /ipad/i.test(userAgent);
-
 export const isMac = /macintosh/i.test(userAgent);
+
+export const isIpad = /ipad/i.test(userAgent) || (isMac && navigator.maxTouchPoints > 1);
 
 export const isIphone = /iphone/i.test(userAgent);
 


### PR DESCRIPTION
iPad上的chrome在桌面请求下，UA中不会显示iPad标识
所以在原有的识别基础上加入多点触摸接口的判断，在PC设备上（包括调试模式），这个值小于等于1

![IMG_0002](https://user-images.githubusercontent.com/32757528/140606022-78b4a1f3-819f-4f38-a33e-527099385ad5.PNG)
